### PR TITLE
Changed line in manifest.in so twitter_bootstrap/less folder is recursive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ include awesome_bootstrap/*.py
 recursive-include awesome_bootstrap/static/twitter_bootstrap/dist *
 include awesome_bootstrap/static/twitter_bootstrap/fonts/*
 include awesome_bootstrap/static/twitter_bootstrap/js/*.js
-include awesome_bootstrap/static/twitter_bootstrap/less/*.less
+recursive-include awesome_bootstrap/static/twitter_bootstrap/less *.less
 include awesome_bootstrap/static/font_awesome/css/*.css
 include awesome_bootstrap/static/font_awesome/fonts/*
 include awesome_bootstrap/static/font_awesome/less/*.less


### PR DESCRIPTION
Bootstrap now includes the mixins sub-directory in its less folder. Changing the manifest to include the less folder recursively makes sure that the mixins folder will get downloaded.
